### PR TITLE
Use CMakeUserPresets.json for CI.

### DIFF
--- a/.github/workflows/CMakeUserPresets.json
+++ b/.github/workflows/CMakeUserPresets.json
@@ -1,0 +1,78 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "clang-libstdcxx",
+      "displayName": "Clang + libstdc++",
+      "inherits": "vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "/usr/bin/clang-18",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++-18"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "clang-libcxx",
+      "displayName": "Clang + libc++",
+      "inherits": "vcpkg",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "/usr/bin/clang-18",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++-18",
+        "CMAKE_CXX_FLAGS": "-stdlib=libc++",
+        "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "msvc",
+      "displayName": "MSVC",
+      "inherits": "vcpkg",
+      "architecture": "x64",
+      "toolset": "v143",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "clang-libstdcxx",
+      "configurePreset": "clang-libstdcxx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "clang-libcxx",
+      "configurePreset": "clang-libcxx",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      }
+    },
+    {
+      "name": "msvc",
+      "configurePreset": "msvc",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    }
+  ]
+}

--- a/.github/workflows/CMakeUserPresets.json
+++ b/.github/workflows/CMakeUserPresets.json
@@ -37,7 +37,6 @@
       "name": "msvc",
       "displayName": "MSVC",
       "inherits": "vcpkg",
-      "toolset": "v143",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",

--- a/.github/workflows/CMakeUserPresets.json
+++ b/.github/workflows/CMakeUserPresets.json
@@ -37,7 +37,6 @@
       "name": "msvc",
       "displayName": "MSVC",
       "inherits": "vcpkg",
-      "architecture": "x64",
       "toolset": "v143",
       "condition": {
         "type": "equals",

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,6 +34,12 @@ jobs:
         run: |
           sudo apt-get install ninja-build libc++-dev libc++abi-dev
 
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg && ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
+
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:
@@ -53,7 +59,7 @@ jobs:
             -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
             -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_OVERLAY_PORTS=overlays \
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,16 +52,13 @@ jobs:
 
       - name: Configure
         run: |
-          mkdir build
-          cmake -S . -B build -G Ninja \
+          cmake --preset=vcpkg \
             -DCMAKE_C_COMPILER="/usr/bin/clang-18" \
             -DCMAKE_CXX_COMPILER="/usr/bin/clang++-18" \
             -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
             -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake \
-            -DVCPKG_OVERLAY_PORTS=overlays \
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: sudo cmake --build build --target install --config ${{ matrix.build }}
+        run: cmake --target install --config ${{ matrix.build }}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,4 +61,4 @@ jobs:
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --target install --config ${{ matrix.build }}
+        run: cmake --build --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -52,13 +52,10 @@ jobs:
 
       - name: Configure
         run: |
-          cmake --preset=vcpkg \
-            -DCMAKE_C_COMPILER="/usr/bin/clang-18" \
-            -DCMAKE_CXX_COMPILER="/usr/bin/clang++-18" \
-            -DCMAKE_CXX_FLAGS="-stdlib=libc++" \
-            -DCMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -lc++abi" \
+          mv .github/workflows/CMakeUserPresets.json .
+          cmake --preset=${{ matrix.use_std_module == 'ON' && 'clang-libcxx' || 'clang-libstdcxx' }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --build --preset=vcpkg --target install
+        run: cmake --build --preset=${{ matrix.use_std_module == 'ON' && 'clang-libcxx' || 'clang-libstdcxx' }} --target install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -61,4 +61,4 @@ jobs:
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --build --target install
+        run: cmake --build --preset=vcpkg --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,12 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
 
+      - name: Install vcpkg
+        run: |
+          git clone https://github.com/microsoft/vcpkg.git
+          cd vcpkg && .\bootstrap-vcpkg.bat
+          echo "VCPKG_ROOT=${{ github.workspace }}/vcpkg" >> $GITHUB_ENV
+
       - name: Export GitHub Actions cache environment variables
         uses: actions/github-script@v7
         with:
@@ -50,7 +56,7 @@ jobs:
           mkdir build
           cmake -S . -B build -G Ninja `
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
+            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_OVERLAY_PORTS=overlays `
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,9 +53,10 @@ jobs:
 
       - name: Configure
         run: |
-          cmake --preset=vcpkg `
+          mv .github\workflows\CMakeUserPresets.json .\
+          cmake --preset=msvc `
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} `
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --build --preset=vcpkg --target install
+        run: cmake --build --preset=msvc --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,4 +58,4 @@ jobs:
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --target install --config ${{ matrix.build }}
+        run: cmake --build --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -53,12 +53,9 @@ jobs:
 
       - name: Configure
         run: |
-          mkdir build
-          cmake -S . -B build -G Ninja `
+          cmake --preset=vcpkg `
             -DCMAKE_BUILD_TYPE=${{ matrix.build }} `
-            -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake" `
-            -DVCPKG_OVERLAY_PORTS=overlays `
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --build build --target install --config ${{ matrix.build }}
+        run: cmake --target install --config ${{ matrix.build }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -58,4 +58,4 @@ jobs:
             -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
 
       - name: Install
-        run: cmake --build --target install
+        run: cmake --build --preset=vcpkg --target install

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,8 +13,8 @@
       "displayName": "vcpkg",
       "description": "Use vcpkg to manage dependencies",
       "inherits": "default",
+      "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
       "cacheVariables": {
-        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_OVERLAY_PORTS": "${sourceDir}/overlays"
       }
     }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,22 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "installDir": "${sourceDir}/install/${presetName}"
+    },
+    {
+      "name": "vcpkg",
+      "displayName": "vcpkg",
+      "description": "Use vcpkg to manage dependencies",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_OVERLAY_PORTS": "${sourceDir}/overlays"
+      }
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,5 +18,15 @@
         "VCPKG_OVERLAY_PORTS": "${sourceDir}/overlays"
       }
     }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "vcpkg",
+      "configurePreset": "vcpkg"
+    }
   ]
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "1dc5ee30eb1032221d29f281f4a94b73f06b4284",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}


### PR DESCRIPTION
This PR gives:
- The "standard" CMake presets (`CMakePresets.json`) for configuration and build. `default` and `vcpkg` are given.
- CI using `CMakeUserPresets.json`. This file is in the CI folder location, and only copied to the CMake source directory (for prevent confusion to the library user). Workflow file gets cleaner.