### PR TITLE
New features: queue family selection and Gpu class.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ target_sources(vku PUBLIC
         interface/details/concepts.cppm
         interface/details/functional.cppm
         interface/details/ranges.cppm
+        interface/Gpu.cppm
         interface/images/mod.cppm
         interface/images/AllocatedImage.cppm
         interface/images/Image.cppm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,7 @@ target_sources(vku PUBLIC
         interface/images/Image.cppm
         interface/pipelines/mod.cppm
         interface/pipelines/Shader.cppm
+        interface/queue.cppm
         interface/rendering/mod.cppm
         interface/rendering/Attachment.cppm
         interface/rendering/AttachmentGroup.cppm

--- a/interface/Gpu.cppm
+++ b/interface/Gpu.cppm
@@ -1,0 +1,306 @@
+module;
+
+#ifndef VKU_USE_STD_MODULE
+#include <cstdint>
+#include <algorithm>
+#include <concepts>
+#include <functional>
+#include <iostream>
+#include <print>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+#endif
+
+#include <vulkan/vulkan_hpp_macros.hpp>
+
+export module vku:Gpu;
+
+#ifdef VKU_USE_STD_MODULE
+import std;
+#endif
+export import vk_mem_alloc_hpp;
+export import vulkan_hpp;
+import :details;
+
+#define CHECK_FEATURE(feature) if (pPhysicalDeviceFeatures->feature && !availableFeatures.feature) { unavailableFeatures.push_back(#feature); }
+
+namespace vku {
+    export template <typename QueueFamilies, std::constructible_from<vk::Device, const QueueFamilies&> Queues> requires
+        requires(vk::PhysicalDevice physicalDevice, const QueueFamilies &queueFamilies) {
+            { Queues::getCreateInfos(physicalDevice, queueFamilies).get() } -> ranges::contiguous_range_of<vk::DeviceQueueCreateInfo>;
+        }
+    class Gpu {
+        [[nodiscard]] static auto getQueueFamilies(vk::PhysicalDevice physicalDevice) noexcept -> QueueFamilies {
+            return QueueFamilies { physicalDevice };
+        }
+
+    public:
+        struct DefaultPhysicalDeviceRater {
+            bool verbose;
+            std::function<QueueFamilies(vk::PhysicalDevice)> queueFamilyGetter;
+            std::span<const char* const> deviceExtensions;
+            const vk::PhysicalDeviceFeatures *pPhysicalDeviceFeatures = nullptr;
+
+            [[nodiscard]] auto operator()(vk::PhysicalDevice physicalDevice) const -> std::uint32_t {
+                const vk::PhysicalDeviceProperties properties = physicalDevice.getProperties();
+                const std::string_view deviceName { properties.deviceName.data() };
+
+                // Check queue family availability.
+                try {
+                    std::ignore = queueFamilyGetter(physicalDevice);
+                }
+                catch (const std::runtime_error &e) {
+                    if (verbose) {
+                        std::println(std::cerr, "Physical device \"{}\" rejected because it failed to get the request queue families: {}", deviceName, e.what());
+                    }
+                    return 0;
+                }
+
+                // Check device extension availability.
+                const std::vector availableExtensions = physicalDevice.enumerateDeviceExtensionProperties();
+
+                constexpr auto toStringView = [](const auto &str) { return std::string_view { str }; };
+                std::vector availableExtensionNames
+                    = availableExtensions
+                    | std::views::transform(&vk::ExtensionProperties::extensionName)
+                    | std::views::transform(toStringView)
+                    | std::ranges::to<std::vector>();
+                std::ranges::sort(availableExtensionNames);
+
+                std::vector deviceExtensionNames
+                    = deviceExtensions
+                    | std::views::transform(toStringView)
+                    | std::ranges::to<std::vector>();
+                std::ranges::sort(deviceExtensionNames);
+
+                if (!std::ranges::includes(availableExtensionNames, deviceExtensionNames)) {
+                    if (verbose) {
+                        std::vector<std::string_view> unavailableExtensions;
+                        std::ranges::set_difference(deviceExtensionNames, availableExtensionNames, std::back_inserter(unavailableExtensions));
+#if __cpp_lib_format_ranges >= 202207L
+                        std::println(std::cerr, "Physical device \"{}\" rejected because it lacks the following device extensions: {::s}", deviceName, unavailableExtensions);
+#else
+                        std::print(std::cerr, "Physical device \"{}\" rejected because it lacks the following device extensions: [", deviceName);
+                        for (std::size_t i = 0; i < unavailableExtensions.size(); ++i) {
+                            if (i == unavailableExtensions.size() - 1) {
+                                std::println(std::cerr, "{}]", unavailableExtensions[i]);
+                            }
+                            else {
+                                std::print(std::cerr, "{}, ", unavailableExtensions[i]);
+                            }
+                        }
+#endif
+                    }
+                    return 0;
+                }
+
+                // Check physical device feature availability.
+                const vk::PhysicalDeviceFeatures availableFeatures = physicalDevice.getFeatures();
+                if (pPhysicalDeviceFeatures) {
+                    // I hope vk::PhysicalDeviceFeatures struct does not change in the future...
+                    std::vector<const char*> unavailableFeatures;
+                    CHECK_FEATURE(robustBufferAccess);
+                    CHECK_FEATURE(fullDrawIndexUint32);
+                    CHECK_FEATURE(imageCubeArray);
+                    CHECK_FEATURE(independentBlend);
+                    CHECK_FEATURE(geometryShader);
+                    CHECK_FEATURE(tessellationShader);
+                    CHECK_FEATURE(sampleRateShading);
+                    CHECK_FEATURE(dualSrcBlend);
+                    CHECK_FEATURE(logicOp);
+                    CHECK_FEATURE(multiDrawIndirect);
+                    CHECK_FEATURE(drawIndirectFirstInstance);
+                    CHECK_FEATURE(depthClamp);
+                    CHECK_FEATURE(depthBiasClamp);
+                    CHECK_FEATURE(fillModeNonSolid);
+                    CHECK_FEATURE(depthBounds);
+                    CHECK_FEATURE(wideLines);
+                    CHECK_FEATURE(largePoints);
+                    CHECK_FEATURE(alphaToOne);
+                    CHECK_FEATURE(multiViewport);
+                    CHECK_FEATURE(samplerAnisotropy);
+                    CHECK_FEATURE(textureCompressionETC2);
+                    CHECK_FEATURE(textureCompressionASTC_LDR);
+                    CHECK_FEATURE(textureCompressionBC);
+                    CHECK_FEATURE(occlusionQueryPrecise);
+                    CHECK_FEATURE(pipelineStatisticsQuery);
+                    CHECK_FEATURE(vertexPipelineStoresAndAtomics);
+                    CHECK_FEATURE(fragmentStoresAndAtomics);
+                    CHECK_FEATURE(shaderTessellationAndGeometryPointSize);
+                    CHECK_FEATURE(shaderImageGatherExtended);
+                    CHECK_FEATURE(shaderStorageImageExtendedFormats);
+                    CHECK_FEATURE(shaderStorageImageMultisample);
+                    CHECK_FEATURE(shaderStorageImageReadWithoutFormat);
+                    CHECK_FEATURE(shaderStorageImageWriteWithoutFormat);
+                    CHECK_FEATURE(shaderUniformBufferArrayDynamicIndexing);
+                    CHECK_FEATURE(shaderSampledImageArrayDynamicIndexing);
+                    CHECK_FEATURE(shaderStorageBufferArrayDynamicIndexing);
+                    CHECK_FEATURE(shaderStorageImageArrayDynamicIndexing);
+                    CHECK_FEATURE(shaderClipDistance);
+                    CHECK_FEATURE(shaderCullDistance);
+                    CHECK_FEATURE(shaderFloat64);
+                    CHECK_FEATURE(shaderInt64);
+                    CHECK_FEATURE(shaderInt16);
+                    CHECK_FEATURE(shaderResourceResidency);
+                    CHECK_FEATURE(shaderResourceMinLod);
+                    CHECK_FEATURE(sparseBinding);
+                    CHECK_FEATURE(sparseResidencyBuffer);
+                    CHECK_FEATURE(sparseResidencyImage2D);
+                    CHECK_FEATURE(sparseResidencyImage3D);
+                    CHECK_FEATURE(sparseResidency2Samples);
+                    CHECK_FEATURE(sparseResidency4Samples);
+                    CHECK_FEATURE(sparseResidency8Samples);
+                    CHECK_FEATURE(sparseResidency16Samples);
+                    CHECK_FEATURE(sparseResidencyAliased);
+                    CHECK_FEATURE(variableMultisampleRate);
+                    CHECK_FEATURE(inheritedQueries);
+
+                    if (!unavailableFeatures.empty()) {
+                        if (verbose) {
+#if __cpp_lib_format_ranges >= 202207L
+                            std::println(std::cerr, "Physical device \"{}\" rejected because it lacks the following physical device features: {::s}", deviceName, unavailableFeatures);
+#else
+                            std::print(std::cerr, "Physical device \"{}\" rejected because it lacks the following physical device features: [", deviceName);
+                            for (std::size_t i = 0; i < unavailableFeatures.size(); ++i) {
+                                if (i == unavailableFeatures.size() - 1) {
+                                    std::println(std::cerr, "{}]", unavailableFeatures[i]);
+                                }
+                                else {
+                                    std::print(std::cerr, "{}, ", unavailableFeatures[i]);
+                                }
+                            }
+#endif
+                        }
+                        return 0;
+                    }
+                }
+
+                std::uint32_t score = 0;
+                if (properties.deviceType == vk::PhysicalDeviceType::eDiscreteGpu) {
+                    score += 1000;
+                }
+
+                score += properties.limits.maxImageDimension2D;
+
+                if (verbose) {
+                    std::println(std::cerr, "Physical device \"{}\" accepted (score={}).", deviceName, score);
+                }
+                return score;
+            }
+        };
+
+        template <typename... DevicePNexts>
+        struct Config {
+            static constexpr bool hasPhysicalDeviceFeatures = !concepts::one_of<vk::PhysicalDeviceFeatures2, DevicePNexts...>;
+
+            bool verbose = false;
+            std::vector<const char*> deviceExtensions = {};
+            [[no_unique_address]]
+            std::conditional_t<hasPhysicalDeviceFeatures, vk::PhysicalDeviceFeatures, std::monostate> physicalDeviceFeatures = {};
+            std::function<QueueFamilies(vk::PhysicalDevice)> queueFamilyGetter = &getQueueFamilies;
+            std::function<std::uint32_t(vk::PhysicalDevice)> physicalDeviceRater
+                = DefaultPhysicalDeviceRater { verbose, queueFamilyGetter, deviceExtensions, hasPhysicalDeviceFeatures ? &physicalDeviceFeatures : nullptr };
+            std::tuple<DevicePNexts...> devicePNexts = {};
+            vma::AllocatorCreateFlags allocatorCreateFlags = {};
+            std::uint32_t apiVersion = vk::makeApiVersion(0, 1, 0, 0);
+        };
+
+        vk::raii::PhysicalDevice physicalDevice;
+        QueueFamilies queueFamilies;
+        vk::raii::Device device;
+        Queues queues { *device, queueFamilies };
+        vma::Allocator allocator;
+
+        template <typename... DevicePNexts>
+        explicit Gpu(
+            const vk::raii::Instance &instance [[clang::lifetimebound]],
+            const Config<DevicePNexts...> &config = {}
+        ) : physicalDevice { selectPhysicalDevice(instance, config) },
+            queueFamilies { config.queueFamilyGetter(physicalDevice) },
+            device { createDevice(config) },
+            allocator { createAllocator(instance, config) } { }
+
+        ~Gpu() {
+            allocator.destroy();
+        }
+
+    private:
+        template <typename... DevicePNexts>
+        [[nodiscard]] auto selectPhysicalDevice(
+            const vk::raii::Instance &instance,
+            const Config<DevicePNexts...> &config
+        ) const -> vk::raii::PhysicalDevice {
+            std::vector physicalDevices = instance.enumeratePhysicalDevices();
+            vk::raii::PhysicalDevice bestPhysicalDevice = *std::ranges::max_element(physicalDevices, {}, config.physicalDeviceRater);
+            if (config.physicalDeviceRater(*bestPhysicalDevice) == 0) {
+                throw std::runtime_error { "No suitable GPU for the application." };
+            }
+            return bestPhysicalDevice;
+        }
+
+        template <typename... PNexts>
+        [[nodiscard]] auto createDevice(
+            const Config<PNexts...> &config
+        ) const -> vk::raii::Device {
+            // This have to be here, because after end of the RefHolder::get() expression, queue priorities are
+            // destroyed (which makes the pointer to them becomes invalid), but it is still in the std::apply scope.
+            const auto queueCreateInfos = Queues::getCreateInfos(*physicalDevice, queueFamilies);
+            vk::raii::Device device { physicalDevice, std::apply([&](const auto &...pNexts) {
+                const vk::PhysicalDeviceFeatures *pPhysicalDeviceFeatures = nullptr;
+                if constexpr (Config<PNexts...>::hasPhysicalDeviceFeatures) {
+                    pPhysicalDeviceFeatures = &config.physicalDeviceFeatures;
+                }
+
+                /* Note:
+                 * Directly returning vk::StructureChain will cause runtime error, because pNexts pointer chain gets
+                 * invalidated. Creating non-const result value and returning it works because of the RVO. After C++17,
+                 * RVO is guaranteed by the standard. */
+                vk::StructureChain createInfo {
+                    vk::DeviceCreateInfo {
+                        {},
+                        queueCreateInfos.get(),
+                        {},
+                        config.deviceExtensions,
+                        pPhysicalDeviceFeatures,
+                    },
+                    pNexts...,
+                };
+
+                return createInfo;
+            }, config.devicePNexts).get() };
+
+#if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+            VULKAN_HPP_DEFAULT_DISPATCHER.init(*device);
+#endif
+            return device;
+        }
+
+        template <typename... DevicePNexts>
+        [[nodiscard]] auto createAllocator(
+            const vk::raii::Instance &instance,
+            const Config<DevicePNexts...> &config
+        ) const -> vma::Allocator {
+            return vma::createAllocator(vma::AllocatorCreateInfo {
+                config.allocatorCreateFlags,
+                *physicalDevice, *device,
+                {}, {}, {}, {},
+#if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
+                vku::unsafeAddress(vma::VulkanFunctions{
+                    instance.getDispatcher()->vkGetInstanceProcAddr,
+                    device.getDispatcher()->vkGetDeviceProcAddr,
+                }),
+#else
+                {},
+#endif
+                *instance, config.apiVersion,
+            });
+        }
+    };
+}

--- a/interface/Gpu.cppm
+++ b/interface/Gpu.cppm
@@ -4,6 +4,7 @@ module;
 #include <cstdint>
 #include <algorithm>
 #include <concepts>
+#include <format>
 #include <functional>
 #include <iostream>
 #include <print>
@@ -28,6 +29,7 @@ import std;
 export import vk_mem_alloc_hpp;
 export import vulkan_hpp;
 import :details;
+import :utils;
 
 #define CHECK_FEATURE(feature) if (pPhysicalDeviceFeatures->feature && !availableFeatures.feature) { unavailableFeatures.push_back(#feature); }
 
@@ -292,7 +294,7 @@ namespace vku {
                 *physicalDevice, *device,
                 {}, {}, {}, {},
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1
-                vku::unsafeAddress(vma::VulkanFunctions{
+                unsafeAddress(vma::VulkanFunctions{
                     instance.getDispatcher()->vkGetInstanceProcAddr,
                     device.getDispatcher()->vkGetDeviceProcAddr,
                 }),

--- a/interface/buffers/AllocatedBuffer.cppm
+++ b/interface/buffers/AllocatedBuffer.cppm
@@ -1,9 +1,11 @@
 module;
 
 #ifndef VKU_USE_STD_MODULE
-#include <string_view>
 #include <tuple>
 #include <utility>
+#ifdef _MSC_VER
+#include <string_view>
+#endif
 #endif
 
 export module vku:buffers.AllocatedBuffer;

--- a/interface/details/concepts.cppm
+++ b/interface/details/concepts.cppm
@@ -1,6 +1,7 @@
 module;
 
 #ifndef VKU_USE_STD_MODULE
+#include <concepts>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -23,6 +24,9 @@ namespace vku::concepts {
     struct is_tuple_like<std::array<T, N>> : std::true_type{};
     export template <typename T>
     concept tuple_like = is_tuple_like<T>::value;
+
+    export template <typename T, typename... Ts>
+    concept one_of = (std::same_as<T, Ts> || ...);
 
     template <typename, typename>
     struct is_alternative_of : std::false_type{};

--- a/interface/details/ranges.cppm
+++ b/interface/details/ranges.cppm
@@ -22,6 +22,9 @@ import std;
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 
 namespace vku::ranges {
+    export template <typename R, typename T>
+    concept contiguous_range_of = std::ranges::contiguous_range<R> && std::same_as<std::ranges::range_value_t<R>, T>;
+
     export template <typename Derived>
 #if !defined(_LIBCPP_VERSION) && __cpp_lib_ranges >= 202202L // https://github.com/llvm/llvm-project/issues/70557#issuecomment-1851936055
         using range_adaptor_closure = std::ranges::range_adaptor_closure<Derived>;

--- a/interface/images/AllocatedImage.cppm
+++ b/interface/images/AllocatedImage.cppm
@@ -1,9 +1,11 @@
 module;
 
 #ifndef VKU_USE_STD_MODULE
-#include <string_view>
 #include <tuple>
 #include <utility>
+#ifdef _MSC_VER
+#include <string_view>
+#endif
 #endif
 
 export module vku:images.AllocatedImage;

--- a/interface/mod.cppm
+++ b/interface/mod.cppm
@@ -11,5 +11,6 @@ export import :descriptors;
 export import :commands;
 export import :images;
 export import :pipelines;
+export import :queue;
 export import :rendering;
 export import :utils;

--- a/interface/mod.cppm
+++ b/interface/mod.cppm
@@ -8,6 +8,7 @@ export module vku;
 export import :buffers;
 export import :constants;
 export import :descriptors;
+export import :Gpu;
 export import :commands;
 export import :images;
 export import :pipelines;

--- a/interface/queue.cppm
+++ b/interface/queue.cppm
@@ -5,6 +5,10 @@ module;
 #include <compare>
 #include <optional>
 #include <span>
+
+#ifdef _MSC_VER
+#include <string_view>
+#endif
 #endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>

--- a/interface/queue.cppm
+++ b/interface/queue.cppm
@@ -1,0 +1,162 @@
+module;
+
+#ifndef VKU_USE_STD_MODULE
+#include <cstdint>
+#include <compare>
+#include <optional>
+#include <span>
+#endif
+
+#include <vulkan/vulkan_hpp_macros.hpp>
+
+export module vku:queue;
+
+#ifdef VKU_USE_STD_MODULE
+import std;
+#endif
+export import vulkan_hpp;
+
+namespace vku {
+    /**
+     * Get compute capable queue family index.
+     * @param queueFamilyProperties Queue family properties. Could be enumerated by <tt>vk::PhysicalDevice::getQueueFamilyProperties</tt>.
+     * @return The index of the compute capable queue family, or <tt>std::nullopt</tt> if not found.
+     */
+    export
+    [[nodiscard]] auto getComputeQueueFamily(
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) noexcept -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eCompute) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get compute specialized (queue flag without graphics) queue family index.
+     * @param queueFamilyProperties Queue family properties. Could be enumerated by <tt>vk::PhysicalDevice::getQueueFamilyProperties</tt>.
+     * @return The index of the compute specialized queue family, or <tt>std::nullopt</tt> if not found.
+     */
+    export
+    [[nodiscard]] auto getComputeSpecializedQueueFamily(
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) noexcept -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eCompute && !(properties.queueFlags & vk::QueueFlagBits::eGraphics)) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get graphics capable queue family index.
+     * @param queueFamilyProperties Queue family properties. Could be enumerated by <tt>vk::PhysicalDevice::getQueueFamilyProperties</tt>.
+     * @return The index of the graphics capable queue family, or <tt>std::nullopt</tt> if not found.
+     */
+    export
+    [[nodiscard]] auto getGraphicsQueueFamily(
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) noexcept -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eGraphics) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get transfer specialized (queue flag without both compute and graphics) queue family index.
+     * @param queueFamilyProperties Queue family properties. Could be enumerated by <tt>vk::PhysicalDevice::getQueueFamilyProperties</tt>.
+     * @return The index of the transfer specialized queue family, or <tt>std::nullopt</tt> if not found.
+     */
+    export
+    [[nodiscard]] auto getTransferQueueFamily(
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) noexcept -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eTransfer && !(properties.queueFlags & (vk::QueueFlagBits::eCompute | vk::QueueFlagBits::eGraphics))) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get present capable queue family index.
+     * @param physicalDevice Vulkan physical device to get queue families from.
+     * @param surface Surface to test for presentation support.
+     * @param queueFamilyCount Number of queue families, which is identical to <tt>physicalDevice.getQueueFamilyProperties().size()</tt>.
+     * @return The index of the present capable queue family, or <tt>std::nullopt</tt> if not found.
+     */
+    export
+    [[nodiscard]] auto getPresentQueueFamily(
+        vk::PhysicalDevice physicalDevice,
+        vk::SurfaceKHR surface,
+        std::uint32_t queueFamilyCount
+    ) -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; i < queueFamilyCount; ++i) {
+            if (physicalDevice.getSurfaceSupportKHR(i, surface)) {
+                return i;
+            }
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get both graphics and present capable queue family index.
+     * @param physicalDevice Vulkan physical device to get queue families from.
+     * @param surface Surface to test for presentation support.
+     * @param queueFamilyProperties Queue family properties, which is identical to <tt>physicalDevice.getQueueFamilyProperties()</tt>.
+     * @return The index of the both graphics and present capable queue family, or <tt>std::nullopt</tt> if not found.
+     * @note
+     * This is useful for the common case of rendering to a window, because it doesn't requires the explicit queue family
+     * ownership transfer between graphics and present queues.
+     */
+    export
+    [[nodiscard]] auto getGraphicsPresentQueueFamily(
+        vk::PhysicalDevice physicalDevice,
+        vk::SurfaceKHR surface,
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eGraphics && physicalDevice.getSurfaceSupportKHR(i, surface)) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+
+    /**
+     * Get both compute and present capable queue family index.
+     * @param physicalDevice Vulkan physical device to get queue families from.
+     * @param surface Surface to test for presentation support.
+     * @param queueFamilyProperties Queue family properties, which is identical to <tt>physicalDevice.getQueueFamilyProperties()</tt>.
+     * @return The index of the both compute and present capable queue family, or <tt>std::nullopt</tt> if not found.
+     * @note
+     * This is useful for compute based window rendering, because it doesn't requires the explicit queue family ownership
+     * transfer between compute and present queues.
+     */
+    export
+    [[nodiscard]] auto getComputePresentQueueFamily(
+        vk::PhysicalDevice physicalDevice,
+        vk::SurfaceKHR surface,
+        std::span<const vk::QueueFamilyProperties> queueFamilyProperties
+    ) -> std::optional<std::uint32_t> {
+        for (std::uint32_t i = 0; const vk::QueueFamilyProperties &properties : queueFamilyProperties) {
+            if (properties.queueFlags & vk::QueueFlagBits::eCompute && physicalDevice.getSurfaceSupportKHR(i, surface)) {
+                return i;
+            }
+            ++i;
+        }
+        return std::nullopt;
+    }
+}


### PR DESCRIPTION
This PR adds two new features:
- Queue family selection helper: get queue family index from enumerated queue family properties, with typical usage pattern (some compute/transfer specialized queue family fetch). Implemented in `queue.cppm` file.
- New class `Gpu<QueueFamilies, Queues>`:  this class bootstraps the physical device, device, queues and allocator creation with simplified parameter passes.