### PR TITLE
Drop support for non standard library module usage.

### DIFF
--- a/.github/workflows/CMakeUserPresets.json
+++ b/.github/workflows/CMakeUserPresets.json
@@ -13,47 +13,16 @@
       "name": "clang",
       "inherits": "ci-test",
       "cacheVariables": {
-        "CMAKE_C_COMPILER": "/usr/bin/clang-18",
-        "CMAKE_CXX_COMPILER": "/usr/bin/clang++-18"
-      },
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Linux"
-      }
-    },
-    {
-      "name": "clang-libcxx",
-      "displayName": "Clang + libc++",
-      "inherits": "clang",
-      "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-stdlib=libc++",
-        "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi"
+        "CMAKE_EXE_LINKER_FLAGS": "-stdlib=libc++ -lc++abi",
+        "CMAKE_C_COMPILER": "/usr/bin/clang",
+        "CMAKE_CXX_COMPILER": "/usr/bin/clang++"
       }
     },
     {
       "name": "msvc",
       "displayName": "MSVC",
-      "inherits": "ci-test",
-      "condition": {
-        "type": "equals",
-        "lhs": "${hostSystemName}",
-        "rhs": "Windows"
-      }
-    }
-  ],
-  "buildPresets": [
-    {
-      "name": "clang",
-      "configurePreset": "clang"
-    },
-    {
-      "name": "clang-libcxx",
-      "configurePreset": "clang-libcxx"
-    },
-    {
-      "name": "msvc",
-      "configurePreset": "msvc"
+      "inherits": "ci-test"
     }
   ]
 }

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,9 +18,8 @@ jobs:
     strategy:
       matrix:
         build: [Debug, Release]
-        use_std_module: [ON, OFF]
 
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -31,13 +30,8 @@ jobs:
           vulkan-components: Vulkan-Headers, Vulkan-Loader
           vulkan-use-cache: true
 
-      - name: Install Ninja and build dependencies
-        run: |
-          sudo apt-get install ninja-build
-
-      - name: Install libc++ if using standard library module
-        if: matrix.use_std_module == 'ON'
-        run: sudo apt-get install libc++-dev libc++abi-dev
+      - name: Install build dependencies
+        run: sudo apt-get install ninja-build libc++-dev libc++abi-dev
 
       - name: Install vcpkg
         run: |
@@ -58,9 +52,7 @@ jobs:
       - name: Configure
         run: |
           mv .github/workflows/CMakeUserPresets.json .
-          cmake --preset=${{ matrix.use_std_module == 'ON' && 'clang-libcxx' || 'clang' }} \
-            -DCMAKE_BUILD_TYPE=${{ matrix.build }} \
-            -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
+          cmake --preset=clang -DCMAKE_BUILD_TYPE=${{ matrix.build }}
 
       - name: Install
-        run: cmake --build --preset=${{ matrix.use_std_module == 'ON' && 'clang-libcxx' || 'clang' }} --target install
+        run: cmake --build build --target install

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -18,7 +18,6 @@ jobs:
     strategy:
       matrix:
         build: [Debug, Release]
-        use_std_module: [ON, OFF]
 
     runs-on: windows-latest
     steps:
@@ -26,8 +25,6 @@ jobs:
 
       - name: Enable Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
-        with:
-          toolset: 14.40
 
       - name: Install Vulkan SDK
         uses: humbletim/setup-vulkan-sdk@v1.2.0
@@ -55,9 +52,7 @@ jobs:
       - name: Configure
         run: |
           mv .github\workflows\CMakeUserPresets.json .\
-          cmake --preset=msvc `
-            -DCMAKE_BUILD_TYPE=${{ matrix.build }} `
-            -DVKU_USE_STD_MODULE=${{ matrix.use_std_module }}
+          cmake --preset=msvc DCMAKE_BUILD_TYPE=${{ matrix.build }}
 
       - name: Install
-        run: cmake --build --preset=msvc --target install
+        run: cmake --build build --target install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.30)
 
-if (VKU_USE_STD_MODULE)
-    # Enable CMake's experimental standard library module support.
-    cmake_minimum_required(VERSION 3.30)
-    set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "0e5b6991-d74f-4b3d-a41c-cf096e0b2508")
-endif()
+# Enable CMake's experimental standard library module support.
+set(CMAKE_EXPERIMENTAL_CXX_IMPORT_STD "0e5b6991-d74f-4b3d-a41c-cf096e0b2508")
 
 project(vku
     LANGUAGES CXX
@@ -13,15 +10,12 @@ project(vku
 )
 
 set(CMAKE_CXX_STANDARD 23)
-if (VKU_USE_STD_MODULE)
-    set(CMAKE_CXX_MODULE_STD 1)
-endif()
+set(CMAKE_CXX_MODULE_STD 1)
 
 # ----------------
 # Project options.
 # ----------------
 
-option(VKU_USE_STD_MODULE "Use the standard library module for compilation.")
 option(VKU_USE_SHADERC "Add runtime GLSL compilation feature by shaderc.")
 option(VKU_DEFAULT_DYNAMIC_DISPATCHER "Use the vk::DispatchLoaderDynamic as the default dispatcher.")
 option(VKU_ENABLE_TEST "Enable the test targets.")
@@ -90,7 +84,6 @@ target_link_libraries(vku PUBLIC
     $<$<BOOL:${VKU_USE_SHADERC}>:Vulkan::shaderc_combined>
 )
 target_compile_definitions(vku PUBLIC
-    $<$<BOOL:${VKU_USE_STD_MODULE}>:VKU_USE_STD_MODULE>
     $<$<BOOL:${VKU_USE_SHADERC}>:VKU_USE_SHADERC>
     $<$<BOOL:${MSVC}>:VULKAN_HPP_NO_SMART_HANDLE VK_NO_PROTOTYPES> # See https://github.com/KhronosGroup/Vulkan-Hpp/blob/main/README.md#c20-named-module for the details.
     $<$<PLATFORM_ID:Darwin>:VK_ENABLE_BETA_EXTENSIONS> # For VK_KHR_portability_subset availability.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,15 +18,5 @@
         "VCPKG_OVERLAY_PORTS": "${sourceDir}/overlays"
       }
     }
-  ],
-  "buildPresets": [
-    {
-      "name": "default",
-      "configurePreset": "default"
-    },
-    {
-      "name": "vcpkg",
-      "configurePreset": "vcpkg"
-    }
   ]
 }

--- a/Doxyfile
+++ b/Doxyfile
@@ -2407,7 +2407,6 @@ PREDEFINED             = VULKAN_HPP_NAMESPACE=vk \
                          VMA_HPP_NAMESPACE=vma \
                          CLANG_INLINE= \
                          NOEXCEPT_IF_RELEASE=noexcept \
-                         VKU_USE_STD_MODULE=1 \
                          VKU_USE_SHADERC=1 \
                          explicit(condition)=explicit # https://github.com/doxygen/doxygen/issues/10085
 
@@ -2423,7 +2422,6 @@ EXPAND_AS_DEFINED      = VULKAN_HPP_NAMESPACE=vk \
                          VMA_HPP_NAMESPACE=vma \
                          CLANG_INLINE= \
                          NOEXCEPT_IF_RELEASE=noexcept \
-                         VKU_USE_STD_MODULE=1 \
                          VKU_USE_SHADERC=1
 
 # If the SKIP_FUNCTION_MACROS tag is set to YES then Doxygen's preprocessor will

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A set of Vulkan utilities based on RAII idiom and Modern C++ features.
 
 ## Features
 
-- Based on C++20 module and (optionally) C++23 standard library module: just single line `import vku;` will cover all. **Module support is mandatory! (No header file provided.)**
+- Based on C++20 module and C++23 standard library module: just single line `import vku;` will cover all. **Module support is mandatory! (No header file provided.)**
 - Can be easily integrated to your existing project by vcpkg.
 - RAII handle for buffer and image with Vulkan Memory Allocator (VMA), with rich set of information.
 - Bootstrapping for physical device, device and VMA allocator generation with fully customizable configurations and compile time safety.

--- a/docs/using-vku.md
+++ b/docs/using-vku.md
@@ -42,13 +42,8 @@ Followings are the **minimum** requirement for building *vku*.
   - Clang 18.1.2 or later
   - MSVC 19.40 or later
 - Build tool
-  - CMake 3.28 or later
+  - CMake 3.30 or later
   - Ninja 1.11
-
-If you want to build *vku* with [C++23 standard library module](https://en.cppreference.com/w/cpp/standard_library#Importing_modules), you need:
-
-- Build tool
-  - CMake 3.30 or later (for experimental `import std;` support: see [here](https://www.kitware.com/import-std-in-cmake-3-30/) for the detail)
 
 ## 3. Building and Installing vku
 
@@ -126,22 +121,7 @@ In future CMake project, you can use `find_package(vku CONFIG REQUIRED)` to use 
 
 ### 3.3. Linux + Clang
 
-For Linux, you'll use Clang and you can choose either libc++ or libstdc++ for STL.
-
-#### Using libstdc++
-
-*vku* provides you `CMakePresets.json` file for this configuration. Use `vcpkg` preset if you're managing dependencies with vcpkg, otherwise use `default` preset.
-
-```sh
-cmake --preset=vcpkg \
-  -DCMAKE_C_COMPILER=/usr/bin/clang \
-  -DCMAKE_CXX_COMPILER=/usr/bin/clang++ # Configure
-cmake --build build --target install # Build and install
-```
-
-#### Using libc++
-
-You have to specify `-stdlib=libc++` flag to your compiler.
+For Linux, you'll use Clang and libc++. You have to specify `-stdlib=libc++` flag to your compiler.
 
 ```sh
 cmake --preset=vcpkg \
@@ -272,7 +252,6 @@ Here are some CMake configuration options. You can pass these options via either
 
 | Option                           | Description                                                  | Default |     vcpkg feature      |
 |----------------------------------|--------------------------------------------------------------|---------|:----------------------:|
-| `VKU_USE_STD_MODULE`             | Use the standard library module for compilation.             | `OFF`   |      `std-module`      |
 | `VKU_USE_SHADERC`                | Add runtime GLSL compilation feature by shaderc.             | `OFF`   |       `shaderc`        |
 | `VKU_DEFAULT_DYNAMIC_DISPATCHER` | Use the vk::DispatchLoaderDynamic as the default dispatcher. | `OFF`   |  `dynamic-dispatcher`  |
 | `VKU_ENABLE_TEST`                | Enable the test targets.                                     | `OFF`   |           -            |

--- a/interface/Gpu.cppm
+++ b/interface/Gpu.cppm
@@ -4,32 +4,12 @@
 module;
 
 #include <version>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <concepts>
-#include <format>
-#include <functional>
-#include <iostream>
-#include <print>
-#include <ranges>
-#include <span>
-#include <stdexcept>
-#include <string_view>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#include <variant>
-#include <vector>
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:Gpu;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vk_mem_alloc_hpp;
 export import vulkan_hpp;
 import :details.concepts;

--- a/interface/buffers/AllocatedBuffer.cppm
+++ b/interface/buffers/AllocatedBuffer.cppm
@@ -3,21 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <tuple>
-#include <utility>
-#ifdef _MSC_VER
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:buffers.AllocatedBuffer;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vk_mem_alloc_hpp;
 export import :buffers.Buffer;
 

--- a/interface/buffers/Buffer.cppm
+++ b/interface/buffers/Buffer.cppm
@@ -3,17 +3,11 @@
 
 module;
 
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:buffers.Buffer;
 
-#if defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
 import std;
-#endif
 export import vulkan_hpp;
 
 namespace vku {

--- a/interface/buffers/MappedBuffer.cppm
+++ b/interface/buffers/MappedBuffer.cppm
@@ -4,26 +4,12 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <concepts>
-#include <ranges>
-#include <span>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#include <variant>
-#endif
 
-#include <span>
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:buffers.MappedBuffer;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import :buffers.AllocatedBuffer;
 import :utils;
 

--- a/interface/buffers/mod.cppm
+++ b/interface/buffers/mod.cppm
@@ -3,13 +3,6 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <compare>
-#include <stdexcept>
-#include <utility>
-#include <variant>
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:buffers;
@@ -17,9 +10,7 @@ export import :buffers.AllocatedBuffer;
 export import :buffers.Buffer;
 export import :buffers.MappedBuffer;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import :utils;
 
 // #define VMA_HPP_NAMESPACE to vma, if not defined.

--- a/interface/commands.cppm
+++ b/interface/commands.cppm
@@ -4,30 +4,12 @@
 module;
 
 #include <version>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <concepts>
-#include <forward_list>
-#include <functional>
-#include <map>
-#include <optional>
-#include <ranges>
-#include <span>
-#include <tuple>
-#include <type_traits>
-#include <unordered_map>
-#include <utility>
-#include <vector>
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:commands;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 import :details.container.OnDemandCounterStorage;
 import :details.tuple;

--- a/interface/constants.cppm
+++ b/interface/constants.cppm
@@ -3,15 +3,11 @@
 
 module;
 
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:constants;
 
-#if defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
+#ifdef _MSC_VER
 import std;
 #endif
 

--- a/interface/debugging.cppm
+++ b/interface/debugging.cppm
@@ -3,17 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <source_location>
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:debugging;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import :details.to_string;
 import :utils;
 

--- a/interface/descriptors/DescriptorSet.cppm
+++ b/interface/descriptors/DescriptorSet.cppm
@@ -3,25 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#include <vector>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:descriptors.DescriptorSet;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import :descriptors.DescriptorSetLayout;
 import :details.concepts;
 import :details.functional;

--- a/interface/descriptors/DescriptorSetLayout.cppm
+++ b/interface/descriptors/DescriptorSetLayout.cppm
@@ -4,21 +4,12 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:descriptors.DescriptorSetLayout;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 export import :descriptors.PoolSizes;
 import :details.concepts;

--- a/interface/descriptors/PoolSizes.cppm
+++ b/interface/descriptors/PoolSizes.cppm
@@ -3,26 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <ranges>
-#include <span>
-#include <tuple>
-#include <type_traits>
-#include <unordered_map>
-#include <vector>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:descriptors.PoolSizes;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 import :details.concepts;
 import :utils.RefHolder;

--- a/interface/descriptors/mod.cppm
+++ b/interface/descriptors/mod.cppm
@@ -3,10 +3,6 @@
 
 module;
 
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#endif
-
 export module vku:descriptors;
 export import :descriptors.DescriptorSetLayout;
 export import :descriptors.DescriptorSet;

--- a/interface/details/concepts.cppm
+++ b/interface/details/concepts.cppm
@@ -1,20 +1,9 @@
 /** @file details/concepts.cppm
  */
 
-module;
-
-#ifndef VKU_USE_STD_MODULE
-#include <concepts>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#endif
-
 export module vku:details.concepts;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 
 namespace details {
     template <typename>

--- a/interface/details/container/OnDemandCounterStorage.cppm
+++ b/interface/details/container/OnDemandCounterStorage.cppm
@@ -1,21 +1,9 @@
 /** @file details/container/OnDemandCounterStorage.cppm
  */
 
-module;
-
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <deque>
-#include <functional>
-#include <type_traits>
-#include <unordered_map>
-#endif
-
 export module vku:details.container.OnDemandCounterStorage;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 

--- a/interface/details/to_string.cppm
+++ b/interface/details/to_string.cppm
@@ -1,19 +1,9 @@
 /** @file details/to_string.cppm
  */
 
-module;
-
-#ifndef VKU_USE_STD_MODULE
-#include <format>
-#include <source_location>
-#include <string>
-#endif
-
 export module vku:details.to_string;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 
 namespace details {
     export

--- a/interface/details/tuple.cppm
+++ b/interface/details/tuple.cppm
@@ -1,19 +1,9 @@
 /** @file details/tuple.cppm
  */
 
-module;
-
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <tuple>
-#include <utility>
-#endif
-
 export module vku:details.tuple;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 
 #define INDEX_SEQ(Is, N, ...) [&]<std::size_t ...Is>(std::index_sequence<Is...>) __VA_ARGS__ (std::make_index_sequence<N>{})
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)

--- a/interface/images/AllocatedImage.cppm
+++ b/interface/images/AllocatedImage.cppm
@@ -3,21 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <tuple>
-#include <utility>
-#ifdef _MSC_VER
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:images.AllocatedImage;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vk_mem_alloc_hpp;
 export import :images.Image;
 

--- a/interface/images/Image.cppm
+++ b/interface/images/Image.cppm
@@ -4,21 +4,12 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <bit>
-#include <ranges>
-#include <utility>
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:images.Image;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 import :utils;
 

--- a/interface/images/mod.cppm
+++ b/interface/images/mod.cppm
@@ -1,12 +1,6 @@
 /** @file images/mod.cppm
  */
 
-module;
-
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#endif
-
 export module vku:images;
 export import :images.Image;
 export import :images.AllocatedImage;

--- a/interface/mod.cppm
+++ b/interface/mod.cppm
@@ -1,13 +1,6 @@
 /** @file mod.cppm
  */
 
-module;
-
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#include <forward_list>
-#endif
-
 export module vku;
 export import :buffers;
 export import :constants;

--- a/interface/pipelines/Shader.cppm
+++ b/interface/pipelines/Shader.cppm
@@ -5,33 +5,15 @@ module;
 
 #include <cassert>
 #include <cerrno>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <cstring>
-#include <filesystem>
-#include <format>
-#include <fstream>
-#include <ios>
-#include <span>
-#include <stdexcept>
-#include <utility>
-#include <vector>
-#endif
 
 #ifdef VKU_USE_SHADERC
-#include <ranges>
-#include <source_location>
-#include <string_view>
-
 #include <shaderc/shaderc.hpp>
 #endif
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:pipelines.Shader;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 import :utils.RefHolder;
 #ifdef VKU_USE_SHADERC

--- a/interface/pipelines/mod.cppm
+++ b/interface/pipelines/mod.cppm
@@ -3,26 +3,12 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <bit>
-#include <concepts>
-#include <stdexcept>
-#include <string_view>
-#include <tuple>
-#include <type_traits>
-#include <utility>
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:pipelines;
 export import :pipelines.Shader;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import :utils.RefHolder;
 
 template <typename T, std::size_t>

--- a/interface/queue.cppm
+++ b/interface/queue.cppm
@@ -3,24 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <optional>
-#include <span>
-
-#ifdef _MSC_VER
-#include <compare>
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:queue;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 
 namespace vku {

--- a/interface/rendering/Attachment.cppm
+++ b/interface/rendering/Attachment.cppm
@@ -3,20 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <vector>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:rendering.Attachment;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import :images.Image;
 
 namespace vku {

--- a/interface/rendering/AttachmentGroup.cppm
+++ b/interface/rendering/AttachmentGroup.cppm
@@ -4,27 +4,12 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <optional>
-#include <ranges>
-#include <span>
-#include <variant>
-#include <vector>
-
-#ifdef _MSC_VER
-#include <forward_list>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:rendering.AttachmentGroup;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import :details.functional;
 export import :rendering.Attachment;
 import :rendering.AttachmentGroupBase;

--- a/interface/rendering/AttachmentGroupBase.cppm
+++ b/interface/rendering/AttachmentGroupBase.cppm
@@ -3,23 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <concepts>
-#include <forward_list>
-#include <utility>
-
-#ifdef _MSC_VER
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:rendering.AttachmentGroupBase;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import :images.AllocatedImage;
 export import :utils;
 

--- a/interface/rendering/MultisampleAttachment.cppm
+++ b/interface/rendering/MultisampleAttachment.cppm
@@ -3,20 +3,11 @@
 
 module;
 
-#ifndef VKU_USE_STD_MODULE
-#include <vector>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:rendering.MultisampleAttachment;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import :images.Image;
 
 namespace vku {

--- a/interface/rendering/MultisampleAttachmentGroup.cppm
+++ b/interface/rendering/MultisampleAttachmentGroup.cppm
@@ -4,27 +4,12 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <optional>
-#include <ranges>
-#include <span>
-#include <variant>
-#include <vector>
-
-#ifdef _MSC_VER
-#include <forward_list>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:rendering.MultisampleAttachmentGroup;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import :details.functional;
 export import :rendering.Attachment;
 import :rendering.AttachmentGroupBase;

--- a/interface/rendering/mod.cppm
+++ b/interface/rendering/mod.cppm
@@ -1,13 +1,6 @@
 /** @file rendering/mod.cppm
  */
 
-module;
-
-#if !defined(VKU_USE_STD_MODULE) && defined(_MSC_VER)
-#include <compare>
-#include <forward_list>
-#endif
-
 export module vku:rendering;
 
 export import :rendering.Attachment;

--- a/interface/utils/RefHolder.cppm
+++ b/interface/utils/RefHolder.cppm
@@ -1,20 +1,9 @@
 /** @file utils/RefHolder.cppm
  */
 
-module;
-
-#ifndef VKU_USE_STD_MODULE
-#include <concepts>
-#include <functional>
-#include <tuple>
-#include <type_traits>
-#endif
-
 export module vku:utils.RefHolder;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 
 #define FWD(...) static_cast<decltype(__VA_ARGS__)&&>(__VA_ARGS__)
 

--- a/interface/utils/mod.cppm
+++ b/interface/utils/mod.cppm
@@ -4,28 +4,13 @@
 module;
 
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <concepts>
-#include <functional>
-#include <initializer_list>
-#include <ranges>
-#include <utility>
-#include <vector>
-#ifdef _MSC_VER
-#include <compare>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
 export module vku:utils;
 export import :utils.RefHolder;
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 export import vulkan_hpp;
 
 #ifdef NDEBUG

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,6 @@
-# TODO: due to the current Clang C++20 module and libstdc++ compatibility, the test is disabled. Enable the test when
-#  it available.
-if (NOT LINUX)
-    add_executable(execute_hierarchical_commands execute_hierarchical_commands.cpp)
-    target_link_libraries(execute_hierarchical_commands PRIVATE vku::vku)
-    add_test(NAME execute_hierarchical_commands COMMAND execute_hierarchical_commands)
-endif()
+add_executable(execute_hierarchical_commands execute_hierarchical_commands.cpp)
+target_link_libraries(execute_hierarchical_commands PRIVATE vku::vku)
+add_test(NAME execute_hierarchical_commands COMMAND execute_hierarchical_commands)
 
 add_executable(get_mip_view_create_infos get_mip_view_create_infos.cpp)
 target_link_libraries(get_mip_view_create_infos PRIVATE vku::vku)

--- a/test/execute_hierarchical_commands.cpp
+++ b/test/execute_hierarchical_commands.cpp
@@ -1,24 +1,8 @@
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <array>
-#include <iterator>
-#include <ranges>
-#include <span>
-#include <stdexcept>
-#include <tuple>
-#include <vector>
-#ifdef _MSC_VER
-#include <format>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/get_mip_view_create_infos.cpp
+++ b/test/get_mip_view_create_infos.cpp
@@ -1,22 +1,8 @@
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <array>
-#include <functional>
-#include <ranges>
-#include <tuple>
-#include <vector>
-#ifdef _MSC_VER
-#include <format>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/msaa-triangle/main.cpp
+++ b/test/msaa-triangle/main.cpp
@@ -1,19 +1,6 @@
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <tuple>
-#include <variant>
-#ifdef _MSC_VER
-#include <forward_list>
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/pool_sizes.cpp
+++ b/test/pool_sizes.cpp
@@ -1,17 +1,6 @@
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <tuple>
-#ifdef _MSC_VER
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/specialization_constant.cpp
+++ b/test/specialization_constant.cpp
@@ -1,18 +1,8 @@
 #include <cassert>
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <tuple>
-#ifdef _MSC_VER
-#include <format>
-#endif
-#endif
 
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/swapchain-msaa-triangle/main.cpp
+++ b/test/swapchain-msaa-triangle/main.cpp
@@ -1,24 +1,6 @@
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <array>
-#include <format>
-#include <ranges>
-#include <stdexcept>
-#include <tuple>
-#include <variant>
-#include <vector>
-#ifdef _MSC_VER
-#include <forward_list>
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/swapchain-triangle/main.cpp
+++ b/test/swapchain-triangle/main.cpp
@@ -1,24 +1,6 @@
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <algorithm>
-#include <array>
-#include <format>
-#include <ranges>
-#include <stdexcept>
-#include <tuple>
-#include <variant>
-#include <vector>
-#ifdef _MSC_VER
-#include <forward_list>
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1

--- a/test/triangle/main.cpp
+++ b/test/triangle/main.cpp
@@ -1,20 +1,6 @@
-#ifndef VKU_USE_STD_MODULE
-#include <cstdint>
-#include <array>
-#include <span>
-#include <tuple>
-#include <variant>
-#ifdef _MSC_VER
-#include <forward_list>
-#include <string_view>
-#endif
-#endif
-
 #include <vulkan/vulkan_hpp_macros.hpp>
 
-#ifdef VKU_USE_STD_MODULE
 import std;
-#endif
 import vku;
 
 #if VULKAN_HPP_DISPATCH_LOADER_DYNAMIC == 1


### PR DESCRIPTION
`VKU_USE_STD_MODULE` CMake variable removed, and always use C++23 standard library module.